### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 accelerate==0.33.0
-diffusers
+git+https://github.com/huggingface/diffusers.git@9214f4a3782a74e510eff7e09b59457fe8b63511 # branch compatible with the recent Allegro update
 numpy==1.24.4
 #torch==2.4.1
 tqdm==4.66.2


### PR DESCRIPTION
Diffusers update broke Allegro. 
Note that all new installs will be broken until this fix!

-> pull the 4 upstream updates from `rhymes-ai/Allegro` 
-> accept this requirements.txt fix

As per their updated `README`, we need to install the diffusers dev until Allegro add the new diffuser pipeline:

I tested pulling in the 4 new updates from upstream and then installing the diffusers dev.  It works. 
Otherwise it complains about missing config attributes and then produces no video after inference. 

After fix it still complains about missing "sample_frames, sample_height, sample_width" attributes which are safely ignored.  I assume these parameters will be in the new diffusers pipeline and relate to running a quicker test inference.

You can test @10 steps via the UI.  only take me 30 minutes, so maybe 15 minutes for you. 